### PR TITLE
Fix incorrect redirecting on protected routes' reload

### DIFF
--- a/src/app/[locale]/(auth)/sign-in/sign-In.test.tsx
+++ b/src/app/[locale]/(auth)/sign-in/sign-In.test.tsx
@@ -20,6 +20,12 @@ jest.mock('@/i18n/navigation', () => ({
   useRouter: jest.fn(() => ({ push: pushMock })),
 }));
 
+const mockUseIsLoggedIn = jest.fn();
+jest.mock('@/hooks/use-user-logged-state', () => ({
+  useUserLoggedState: () =>
+    mockUseIsLoggedIn() as { isLoggedIn: boolean; isLoading: boolean },
+}));
+
 const messages = {
   authForms: {
     signIn: {
@@ -61,7 +67,11 @@ const renderWithProvider = (component: JSX.Element) =>
   );
 
 describe('SignInPage (AuthForm)', () => {
-  beforeEach(() => {
+  beforeAll(() => {
+    mockUseIsLoggedIn.mockReturnValue({ isLoggedIn: false, isLoading: false });
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/src/app/[locale]/(auth)/sign-up/sign-Up.test.tsx
+++ b/src/app/[locale]/(auth)/sign-up/sign-Up.test.tsx
@@ -20,6 +20,12 @@ jest.mock('@/i18n/navigation', () => ({
   useRouter: jest.fn(() => ({ push: pushMock })),
 }));
 
+const mockUseIsLoggedIn = jest.fn();
+jest.mock('@/hooks/use-user-logged-state', () => ({
+  useUserLoggedState: () =>
+    mockUseIsLoggedIn() as { isLoggedIn: boolean; isLoading: boolean },
+}));
+
 const messages = {
   authForms: {
     signUp: {
@@ -70,7 +76,15 @@ const renderWithProvider = (component: JSX.Element) =>
   );
 
 describe('SigUpnPage (AuthForm)', () => {
-  it('should render SignInPage', async () => {
+  beforeAll(() => {
+    mockUseIsLoggedIn.mockReturnValue({ isLoggedIn: false, isLoading: false });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render SignUpPage', async () => {
     renderWithProvider(<SignUpPage />);
     const heading = await screen.findByRole('heading', { name: /Sign Up/i });
     expect(heading).toBeInTheDocument();

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,13 +8,13 @@ import { useTranslations } from 'next-intl';
 import Loader from '@/components/layout/loader/loader';
 import { AUTH_LINKS, CLIENT_LINKS } from '@/constants/links';
 import { useAppSelector } from '@/hooks/redux';
-import { useIsLoggedIn } from '@/hooks/use-is-logged-in';
+import { useUserLoggedState } from '@/hooks/use-user-logged-state';
 import { Link } from '@/i18n/navigation';
 
 export default function Home() {
   const t = useTranslations('home_general');
   const { user, loading } = useAppSelector((state) => state.user);
-  const isLoggedIn = useIsLoggedIn();
+  const { isLoggedIn } = useUserLoggedState();
 
   if (loading) {
     return <Loader />;

--- a/src/components/auth/with-auth.test.tsx
+++ b/src/components/auth/with-auth.test.tsx
@@ -5,8 +5,9 @@ import { render, screen } from '@testing-library/react';
 import withAuth from './with-auth';
 
 const mockUseIsLoggedIn = jest.fn();
-jest.mock('@/hooks/use-is-logged-in', () => ({
-  useIsLoggedIn: () => mockUseIsLoggedIn() as boolean,
+jest.mock('@/hooks/use-user-logged-state', () => ({
+  useUserLoggedState: () =>
+    mockUseIsLoggedIn() as { isLoggedIn: boolean; isLoading: boolean },
 }));
 
 const mockRouterReplace = jest.fn();
@@ -32,21 +33,29 @@ describe('withAuth HOC', () => {
   });
 
   describe('when protecting a private route', () => {
-    it('should render the component if the user is logged in', () => {
-      mockUseIsLoggedIn.mockReturnValue(true);
+    it('should render the component if the user is logged in', async () => {
+      mockUseIsLoggedIn.mockReturnValue({
+        isLoggedIn: true,
+        isLoading: false,
+      });
       const ProtectedComponent = withAuth(MockComponent);
 
       render(<ProtectedComponent />);
 
-      expect(screen.getByText('Protected Content')).toBeInTheDocument();
+      const content = await screen.findByText('Protected Content');
+      expect(content).toBeInTheDocument();
 
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      const loader = screen.queryByText('Loading...');
+      expect(loader).not.toBeInTheDocument();
 
       expect(mockRouterReplace).not.toHaveBeenCalled();
     });
 
     it('should render Loader and redirect if the user is not logged in', () => {
-      mockUseIsLoggedIn.mockReturnValue(false);
+      mockUseIsLoggedIn.mockReturnValue({
+        isLoggedIn: false,
+        isLoading: false,
+      });
       const ProtectedComponent = withAuth(MockComponent);
 
       render(<ProtectedComponent />);
@@ -62,7 +71,10 @@ describe('withAuth HOC', () => {
 
   describe('when protecting a non-private route', () => {
     it('should render the component if the user is NOT logged in', () => {
-      mockUseIsLoggedIn.mockReturnValue(false);
+      mockUseIsLoggedIn.mockReturnValue({
+        isLoggedIn: false,
+        isLoading: false,
+      });
       const PublicComponent = withAuth(MockComponent, {
         reverseCondition: true,
       });
@@ -75,7 +87,10 @@ describe('withAuth HOC', () => {
     });
 
     it('should render Loader and redirect if the user IS logged in', () => {
-      mockUseIsLoggedIn.mockReturnValue(true);
+      mockUseIsLoggedIn.mockReturnValue({
+        isLoggedIn: true,
+        isLoading: false,
+      });
       const PublicComponent = withAuth(MockComponent, {
         reverseCondition: true,
       });

--- a/src/components/auth/with-auth.tsx
+++ b/src/components/auth/with-auth.tsx
@@ -4,7 +4,7 @@ import type { ComponentType } from 'react';
 import { useEffect } from 'react';
 
 import Loader from '@/components/layout/loader/loader';
-import { useIsLoggedIn } from '@/hooks/use-is-logged-in';
+import { useUserLoggedState } from '@/hooks/use-user-logged-state';
 import { useRouter } from '@/i18n/navigation';
 
 export default function withAuth(
@@ -13,16 +13,20 @@ export default function withAuth(
 ) {
   return function WithAuth() {
     const router = useRouter();
-    const isLoggedIn = useIsLoggedIn();
+    const { isLoggedIn, isLoading } = useUserLoggedState();
 
-    const redirectCondition = reverseCondition ? !isLoggedIn : isLoggedIn;
+    const needRedirect = reverseCondition ? isLoggedIn : !isLoggedIn;
 
     useEffect(() => {
-      if (!redirectCondition) {
+      if (needRedirect && !isLoading) {
         router.replace(reverseCondition ? '/' : '/sign-in');
       }
-    }, [redirectCondition, router]);
+    }, [needRedirect, router, isLoading]);
 
-    return redirectCondition ? <WrappedComponent /> : <Loader />;
+    if (isLoading) {
+      return <Loader />;
+    }
+
+    return needRedirect ? <Loader /> : <WrappedComponent />;
   };
 }

--- a/src/hooks/use-user-logged-state.ts
+++ b/src/hooks/use-user-logged-state.ts
@@ -1,7 +1,7 @@
 import { useAppSelector } from '@/hooks/redux';
 import { isTokenValid } from '@/utils/firebase/tokenValidation';
 
-export function useIsLoggedIn() {
+export function useUserLoggedState() {
   const currentUserName = useAppSelector(
     (state) => state.user.user?.displayName
   );
@@ -10,6 +10,7 @@ export function useIsLoggedIn() {
   );
   const isLoggedIn =
     Boolean(currentUserName) && isTokenValid(tokenExpirationTime);
+  const isLoading = useAppSelector((state) => state.user.loading);
 
-  return isLoggedIn;
+  return { isLoggedIn, isLoading };
 }


### PR DESCRIPTION
# Description

This pr fixes incorrect redirects when reloading the page on `/client`, `/history` and `/variables` routes while the user is logged in.

## Related Task

N / A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration
- [x] Code refactoring
- [ ] Documentation
- [ ] Other:

## Author's Checklist

- [x My code follows the style guidelines of this project (ESLint / Prettier)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [x] The PR title is clear and reflects the changes
- [x] The PR is targeted to the correct branch (`feature/auth-redirect`)
