### PR TITLE
fixed memory routing after sign-out

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,14 +23,13 @@ const config = {
   coveragePathIgnorePatterns: [
     '<rootDir>/src/__test__/mocks/',
     '<rootDir>/src/lib/',
-    '<rootDir>/src/test/mocks/',
     'page.tsx',
   ],
   testMatch: [
     '**/__tests__/**/*.?([mc])[jt]s?(x)',
     '**/?(*.)+(spec|test).?([mc])[jt]s?(x)',
   ],
-  testTimeout: 15000,
+  testTimeout: 50000,
 };
 
 const createJestConfigWithOverrides = async () => ({

--- a/src/components/layout/header/auth-panel/auth-panel.test.tsx
+++ b/src/components/layout/header/auth-panel/auth-panel.test.tsx
@@ -20,7 +20,7 @@ jest.mock('@/i18n/navigation', () => ({
   ),
   usePathname: () => '/',
   useRouter: () => ({
-    push: jest.fn(),
+    replace: jest.fn(),
   }),
 }));
 
@@ -48,7 +48,6 @@ describe('AuthPanel', () => {
         userId: 'user1',
         displayName: 'Alex',
         expiresIn: Date.now() + 1000,
-        isNewUser: false,
       },
       isValid: true,
       loading: false,

--- a/src/components/layout/header/auth-panel/auth-panel.tsx
+++ b/src/components/layout/header/auth-panel/auth-panel.tsx
@@ -43,7 +43,7 @@ export default function AuthPanel({
     ) {
       void userLogout(tToast, 'expired');
       dispatch(clearUser());
-      router.push('/');
+      router.replace('/');
     }
   }, [currentUser, loading, dispatch, tToast, router]);
 
@@ -51,7 +51,7 @@ export default function AuthPanel({
     await userLogout(tToast);
     closeSidebar();
     dispatch(clearUser());
-    router.push('/');
+    router.replace('/');
   };
 
   if (loading) {


### PR DESCRIPTION
# Description

It is not possible to visit private pages after logging out.

## Related Task

Closed N / A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration
- [ ] Code refactoring
- [ ] Documentation
- [ ] Other:

## Author's Checklist

- [x] My code follows the style guidelines of this project (ESLint / Prettier)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [x] The PR title is clear and reflects the changes
- [x] The PR is targeted to the correct branch (`develop`)
